### PR TITLE
Fix failing DelayedJob spec

### DIFF
--- a/lib/opbeat/integrations/delayed_job.rb
+++ b/lib/opbeat/integrations/delayed_job.rb
@@ -19,7 +19,7 @@ if defined?(Delayed)
               # Log error to Opbeat
               ::Opbeat.capture_exception(exception)
               # Make sure we propagate the failure!
-              raise exception
+              raise
             end
           end
         end


### PR DESCRIPTION
`DelayedJob::Worker.work_off` doesn't raise exceptions.